### PR TITLE
Optimize ranking API with caching, SQL optimization, and in-memory locks

### DIFF
--- a/go/isuports.go
+++ b/go/isuports.go
@@ -15,9 +15,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -48,8 +48,47 @@ var (
 
 	adminDB *sqlx.DB
 
+	// ランキングキャッシュ
+	rankingCache     sync.Map // key: competitionID:rankAfter, value: []CompetitionRank
+	competitionCache sync.Map // key: competitionID, value: *CompetitionRow
+
+	// テナントごとのメモリ内ロック
+	tenantLocks sync.Map // key: tenantID, value: *sync.RWMutex
+
 	sqliteDriverName = "sqlite3"
 )
+
+// ランキングキャッシュのキーを生成
+func makeRankingCacheKey(competitionID string, rankAfter int64) string {
+	return fmt.Sprintf("%s:%d", competitionID, rankAfter)
+}
+
+// テナントのロックを取得
+func getTenantLock(tenantID int64) *sync.RWMutex {
+	lockVal, _ := tenantLocks.LoadOrStore(tenantID, &sync.RWMutex{})
+	return lockVal.(*sync.RWMutex)
+}
+
+// 大会情報をキャッシュから取得
+func getCompetitionWithCache(ctx context.Context, tenantDB dbOrTx, competitionID string) (*CompetitionRow, error) {
+	// キャッシュから取得を試みる
+	if cachedVal, ok := competitionCache.Load(competitionID); ok {
+		return cachedVal.(*CompetitionRow), nil
+	}
+
+	// キャッシュになければDBから取得
+	comp, err := retrieveCompetition(ctx, tenantDB, competitionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 終了した大会のみキャッシュする
+	if comp.FinishedAt.Valid {
+		competitionCache.Store(competitionID, comp)
+	}
+
+	return comp, nil
+}
 
 // 環境変数を取得する、なければデフォルト値を返す
 func getEnv(key string, defaultValue string) string {
@@ -1315,8 +1354,8 @@ func competitionRankingHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "competition_id is required")
 	}
 
-	// 大会の存在確認
-	competition, err := retrieveCompetition(ctx, tenantDB, competitionID)
+	// 大会の存在確認（キャッシュ対応）
+	competition, err := getCompetitionWithCache(ctx, tenantDB, competitionID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return echo.NewHTTPError(http.StatusNotFound, "competition not found")
@@ -1349,62 +1388,96 @@ func competitionRankingHandler(c echo.Context) error {
 		}
 	}
 
-	// player_scoreを読んでいるときに更新が走ると不整合が起こるのでロックを取得する
-	fl, err := flockByTenantID(v.tenantID)
-	if err != nil {
-		return fmt.Errorf("error flockByTenantID: %w", err)
+	// キャッシュからランキングを取得を試みる（終了した大会のみ）
+	if competition.FinishedAt.Valid {
+		cacheKey := makeRankingCacheKey(competitionID, rankAfter)
+		if cachedRanks, ok := rankingCache.Load(cacheKey); ok {
+			res := SuccessResult{
+				Status: true,
+				Data: CompetitionRankingHandlerResult{
+					Competition: CompetitionDetail{
+						ID:         competition.ID,
+						Title:      competition.Title,
+						IsFinished: true,
+					},
+					Ranks: cachedRanks.([]CompetitionRank),
+				},
+			}
+			return c.JSON(http.StatusOK, res)
+		}
 	}
-	defer fl.Close()
-	pss := []PlayerScoreRow{}
+
+	// ファイルベースのロックではなくメモリ内ロックを使用
+	lock := getTenantLock(v.tenantID)
+	lock.RLock()
+	defer lock.RUnlock()
+
+	// N+1問題を解消するために、プレイヤー情報を一括取得
+	// SQLでソートも行う
+	type PlayerScoreWithRank struct {
+		PlayerID    string `db:"player_id"`
+		Score       int64  `db:"score"`
+		RowNum      int64  `db:"row_num"`
+		DisplayName string `db:"display_name"`
+		RankNum     int64  `db:"rank_num"`
+	}
+
+	// 最新のスコアを取得し、スコア降順、row_num昇順でソート
+	query := `
+		WITH ranked_scores AS (
+			SELECT
+				ps.player_id,
+				ps.score,
+				ps.row_num,
+				p.display_name,
+				ROW_NUMBER() OVER (ORDER BY ps.score DESC, ps.row_num ASC) as rank_num
+			FROM (
+				SELECT
+					player_id,
+					MAX(row_num) as max_row_num
+				FROM
+					player_score
+				WHERE
+					tenant_id = ? AND competition_id = ?
+				GROUP BY
+					player_id
+			) latest
+			JOIN player_score ps ON ps.player_id = latest.player_id AND ps.row_num = latest.max_row_num
+			JOIN player p ON p.id = ps.player_id
+			WHERE
+				ps.tenant_id = ? AND ps.competition_id = ?
+		)
+		SELECT * FROM ranked_scores
+		WHERE rank_num > ?
+		ORDER BY rank_num
+		LIMIT 100
+	`
+
+	rankedScores := []PlayerScoreWithRank{}
 	if err := tenantDB.SelectContext(
 		ctx,
-		&pss,
-		"SELECT * FROM player_score WHERE tenant_id = ? AND competition_id = ? ORDER BY row_num DESC",
-		tenant.ID,
-		competitionID,
+		&rankedScores,
+		query,
+		tenant.ID, competitionID, tenant.ID, competitionID, rankAfter,
 	); err != nil {
-		return fmt.Errorf("error Select player_score: tenantID=%d, competitionID=%s, %w", tenant.ID, competitionID, err)
+		return fmt.Errorf("error Select player_score with rank: %w", err)
 	}
-	ranks := make([]CompetitionRank, 0, len(pss))
-	scoredPlayerSet := make(map[string]struct{}, len(pss))
-	for _, ps := range pss {
-		// player_scoreが同一player_id内ではrow_numの降順でソートされているので
-		// 現れたのが2回目以降のplayer_idはより大きいrow_numでスコアが出ているとみなせる
-		if _, ok := scoredPlayerSet[ps.PlayerID]; ok {
-			continue
-		}
-		scoredPlayerSet[ps.PlayerID] = struct{}{}
-		p, err := retrievePlayer(ctx, tenantDB, ps.PlayerID)
-		if err != nil {
-			return fmt.Errorf("error retrievePlayer: %w", err)
-		}
-		ranks = append(ranks, CompetitionRank{
-			Score:             ps.Score,
-			PlayerID:          p.ID,
-			PlayerDisplayName: p.DisplayName,
-			RowNum:            ps.RowNum,
-		})
-	}
-	sort.Slice(ranks, func(i, j int) bool {
-		if ranks[i].Score == ranks[j].Score {
-			return ranks[i].RowNum < ranks[j].RowNum
-		}
-		return ranks[i].Score > ranks[j].Score
-	})
-	pagedRanks := make([]CompetitionRank, 0, 100)
-	for i, rank := range ranks {
-		if int64(i) < rankAfter {
-			continue
-		}
+
+	// ランキング結果を構築
+	pagedRanks := make([]CompetitionRank, 0, len(rankedScores))
+	for _, rs := range rankedScores {
 		pagedRanks = append(pagedRanks, CompetitionRank{
-			Rank:              int64(i + 1),
-			Score:             rank.Score,
-			PlayerID:          rank.PlayerID,
-			PlayerDisplayName: rank.PlayerDisplayName,
+			Rank:              rs.RankNum,
+			Score:             rs.Score,
+			PlayerID:          rs.PlayerID,
+			PlayerDisplayName: rs.DisplayName,
 		})
-		if len(pagedRanks) >= 100 {
-			break
-		}
+	}
+
+	// 終了した大会の場合はキャッシュに保存
+	if competition.FinishedAt.Valid {
+		cacheKey := makeRankingCacheKey(competitionID, rankAfter)
+		rankingCache.Store(cacheKey, pagedRanks)
 	}
 
 	res := SuccessResult{


### PR DESCRIPTION
## 実装内容

ランキング取得API（）を最適化しました。kataribe結果から、このエンドポイントが最も時間がかかっていることが判明したため、優先的に最適化しました。

1. **キャッシュの導入**:
   - 大会情報のキャッシュ
   - ランキング結果のキャッシュ（特に終了した大会）

2. **N+1問題の解消**:
   - プレイヤー情報を一括取得するSQLクエリを実装

3. **SQLでのソート実装**:
   - アプリケーション側でのソートをSQLに移行
   - 句とウィンドウ関数を使用して効率的なランキング計算

4. **ファイルベースロックの最適化**:
   - ファイルベースのロックをメモリ内ロックに変更

## 期待される効果

kataribe結果によると、このエンドポイントは合計時間1768.754秒、平均1.4851秒かかっていました。この最適化により、以下の効果が期待されます：

1. **レスポンス時間の短縮**:
   - キャッシュにより、特に終了した大会のランキング取得が高速化
   - SQLの最適化により、データベースの処理時間が短縮

2. **スケーラビリティの向上**:
   - メモリ内ロックにより、複数リクエスト時のパフォーマンスが向上
   - N+1問題の解消により、データベースの負荷が軽減